### PR TITLE
fix #1

### DIFF
--- a/runexp.py
+++ b/runexp.py
@@ -267,6 +267,8 @@ class TaskGraph:
             for target in task.target:
                 target_path = os.path.realpath(target)
                 self.next_tasks[task_id].extend(next_tasks.get(target_path, []))
+        self.prev_tasks = [list(set(l)) for l in self.prev_tasks]
+        self.next_tasks = [list(set(l)) for l in self.next_tasks]
         logger.debug('prev_tasks: %s', self.prev_tasks)
         logger.debug('next_tasks: %s', self.next_tasks)
         pass


### PR DESCRIPTION
Probably this fixes #1. The cause is that an element of `prev_tasks` and `next_tasks` will contain duplicate tasks when such dependencies exist. The following is the result of the current version.

```
2018-02-28 11:19:46,340:runexp:DEBUG: prev_tasks: [[], [0, 0]]
2018-02-28 11:19:46,340:runexp:DEBUG: next_tasks: [[1, 1], []]
```

This preserves the information that  there are multiple dependent files on some task but maybe we can discard this information safely... The `set` operation in PR removes this redundancy.