### PR TITLE
fix a bug related to disabling cmdline parsing

### DIFF
--- a/runexp.py
+++ b/runexp.py
@@ -885,6 +885,8 @@ class Workflow:
             arguments = self.parse_args(args)
             if arguments.config is not None:
                 config = arguments.config
+        else:
+            arguments = None
 
         # initialize with configuration file
         if config is not None:


### PR DESCRIPTION
I found a small bug that occurs when I disable the default command line parser (by passing `args=None` to `Workflow`.
In this pull request, I fixed this issue.